### PR TITLE
Speed gain de deeper the higher

### DIFF
--- a/.github/workflows/mandelbrot_sonar.yml
+++ b/.github/workflows/mandelbrot_sonar.yml
@@ -101,4 +101,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           java -version
-          sonar-scanner -Dsonar.projectKey=ckormanyos_mandelbrot -Dsonar.projectName=mandelbrot --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner -Dsonar.projectKey=S-Streulicht_mandelbrot -Dsonar.projectName=mandelbrot --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/.github/workflows/mandelbrot_sonar.yml
+++ b/.github/workflows/mandelbrot_sonar.yml
@@ -101,4 +101,4 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           java -version
-          sonar-scanner -Dsonar.projectKey=S-Streulicht_mandelbrot -Dsonar.projectName=mandelbrot --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner -Dsonar.projectKey=ckormanyos_mandelbrot -Dsonar.projectName=mandelbrot --define sonar.host.url="${{ env.SONAR_SERVER_URL }}" --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/mandelbrot/cfg/mandelbrot_cfg.h
+++ b/mandelbrot/cfg/mandelbrot_cfg.h
@@ -43,6 +43,10 @@
   boost::multiprecision::number<boost::multiprecision::cpp_dec_float<static_cast<unsigned>(mandelbrot_digits10)>,\
                                 boost::multiprecision::et_off>
 
+  #define MANDELBROT_PRECISION_NUMBER_TYPE_NAME(mandelbrot_calc_digits10) /* NOLINT(cppcoreguidelines-macro-usage) */ \
+  boost::multiprecision::number<boost::multiprecision::cpp_dec_float<static_cast<unsigned>(mandelbrot_calc_digits10)>,\
+                                boost::multiprecision::et_off>
+
   #endif
 
   #if(__cplusplus >= 201703L)
@@ -53,7 +57,8 @@
 
   namespace detail {
 
-  using numeric_type = MANDELBROT_NUMBER_TYPE_NAME( MANDELBROT_CALCULATION_DIGITS10 ); // NOLINT(cppcoreguidelines-macro-usage)
+  using      numeric_type = MANDELBROT_NUMBER_TYPE_NAME( MANDELBROT_SETUP_DIGITS10 ); // NOLINT(cppcoreguidelines-macro-usage)
+  using calc_numeric_type = MANDELBROT_NUMBER_TYPE_NAME( MANDELBROT_CALCULATION_DIGITS10 ); // NOLINT(cppcoreguidelines-macro-usage)
 
   } // namespace detail
 
@@ -69,11 +74,13 @@
 
   using mandelbrot_config_type  =
     ckormanyos::mandelbrot::mandelbrot_config<detail::numeric_type,
+                                              detail::calc_numeric_type,
                                               static_cast<std::uint_fast32_t>(MANDELBROT_CALCULATION_ITERATIONS),
                                               static_cast<std::uint_fast32_t>(MANDELBROT_CALCULATION_PIXELS_X),
                                               static_cast<std::uint_fast32_t>(MANDELBROT_CALCULATION_PIXELS_Y)>;
 
   using mandelbrot_numeric_type = typename mandelbrot_config_type::my_mandelbrot_config_numeric_type;
+  using mandelbrot_calc_numeric_type = typename mandelbrot_config_type::my_mandelbrot_config_calc_numeric_type;
 
   inline auto dx_half () -> mandelbrot_numeric_type { return mandelbrot_numeric_type(MANDELBROT_POINT_DX_HALF); }
   inline auto dy_half()  -> mandelbrot_numeric_type { return mandelbrot_numeric_type(MANDELBROT_POINT_DY_HALF); }

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_01_FULL.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_01_FULL.h
@@ -12,7 +12,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_01_FULL";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      37;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      37;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      17;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_03_TOP.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_03_TOP.h
@@ -12,7 +12,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_03_TOP";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      31;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      31;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      17;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_04_SWIRL.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_04_SWIRL.h
@@ -12,7 +12,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_04_SWIRL";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      31;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      31;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_05_SEAHORSES.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_05_SEAHORSES.h
@@ -26,7 +26,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_05_SEAHORSES"; // NOLINT(cppcoreguidelines-avoid-c-arrays,hicpp-avoid-c-arrays,modernize-avoid-c-arrays)
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      37;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      37;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      17;
   #if !defined(MANDELBROT_TEST_OPTION_REDUCE_TEST_DEPTH)
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_06_BRANCHES.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_06_BRANCHES.h
@@ -12,7 +12,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_06_BRANCHES";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      31;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      31;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      17;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_07_SEAHORSE_VALLEY.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_07_SEAHORSE_VALLEY.h
@@ -12,7 +12,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_07_SEAHORSE_VALLEY";
 
-  constexpr int MANDELBROT_CALCULATION_DIGITS10     =     31;
+  constexpr int MANDELBROT_SETUP_DIGITS10           =     31;
+  constexpr int MANDELBROT_CALCULATION_DIGITS10     =     17;
   constexpr int MANDELBROT_CALCULATION_PIXELS_X     =   2048;
   constexpr int MANDELBROT_CALCULATION_PIXELS_Y     =   2048;
   constexpr int MANDELBROT_CALCULATION_ITERATIONS   =   2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_08_DEEP_DIVE_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_08_DEEP_DIVE_01.h
@@ -13,7 +13,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_08_DEEP_DIVE_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     143;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     143;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_08_DEEP_DIVE_01_magnify51.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_08_DEEP_DIVE_01_magnify51.h
@@ -13,9 +13,10 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_08_DEEP_DIVE_01_magnify51";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      76;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      76;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
-  constexpr int  MANDELBROT_CALCULATION_PIXELS_Y     =   2048;
+  constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    2000;
 
   constexpr char MANDELBROT_POINT_DX_HALF[]         = "1.4E-51";

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_09_DEEP_DIVE_02.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_09_DEEP_DIVE_02.h
@@ -13,7 +13,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_09_DEEP_DIVE_02";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      95;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      95;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   15000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_10_ZOOM_WIKI_00.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_10_ZOOM_WIKI_00.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_10_ZOOM_WIKI_00";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      55;
+  constexpr int  MANDELBROT_SETUPs_DIGITS10         =      55;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   20000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_10_ZOOM_WIKI_00_rect.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_10_ZOOM_WIKI_00_rect.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_10_ZOOM_WIKI_00_rect";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      60;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      60;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    3840;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2160;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =  100000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_11_ZOOM_WIKI_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_11_ZOOM_WIKI_01.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_11_ZOOM_WIKI_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      55;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      55;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   30000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_12_ZOOM_WIKI_02.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_12_ZOOM_WIKI_02.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_12_ZOOM_WIKI_02";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      55;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      55;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   40000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_13_ZOOM_WIKI_03.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_13_ZOOM_WIKI_03.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_13_ZOOM_WIKI_03";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      55;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      55;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   40000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_14_ZOOM_WIKI_04.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_14_ZOOM_WIKI_04.h
@@ -14,7 +14,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_14_ZOOM_WIKI_04";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      55;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      55;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   40000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_20_ZOOM_VERY_DEEP_00.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_20_ZOOM_VERY_DEEP_00.h
@@ -22,7 +22,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_20_ZOOM_VERY_DEEP_00";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     365;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     365;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_20_ZOOM_VERY_DEEP_00_magnify51.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_20_ZOOM_VERY_DEEP_00_magnify51.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_20_ZOOM_VERY_DEEP_00_magnify51";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      76;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      76;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   30000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_25_ZOOM_SEARCH_00.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_25_ZOOM_SEARCH_00.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_25_ZOOM_SEARCH_00";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      58;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      58;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =    8000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_25_ZOOM_SEARCH_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_25_ZOOM_SEARCH_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_25_ZOOM_SEARCH_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      48;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      48;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =  140000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_30_ZOOM_ANOTHER_00.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_30_ZOOM_ANOTHER_00.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_30_ZOOM_ANOTHER_00";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     287;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     287;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_30_ZOOM_ANOTHER_00_magnify51.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_30_ZOOM_ANOTHER_00_magnify51.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_30_ZOOM_ANOTHER_00_magnify51";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      76;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      76;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;
 

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_31_ZOOM_ANOTHER_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_31_ZOOM_ANOTHER_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_31_ZOOM_ANOTHER_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     287;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     287;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_32_ZOOM_ANOTHER_02.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_32_ZOOM_ANOTHER_02.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_32_ZOOM_ANOTHER_02";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     247;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     247;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_40_SEAHORSE_DIVE_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_40_SEAHORSE_DIVE_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_40_SEAHORSE_DIVE_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     34;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     34;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     17;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =   2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =   2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =  10000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_45_SEAHORSE_OTHER_01_magnify51.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_45_SEAHORSE_OTHER_01_magnify51.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_45_SEAHORSE_OTHER_01_magnify51";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     76;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     76;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =   2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =   2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =  30000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_50_TENDRIL_AREA_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_50_TENDRIL_AREA_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_50_TENDRIL_AREA_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      84;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      84;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   20000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_60_SATELITE_REGION_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_60_SATELITE_REGION_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_60_SATELITE_REGION_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =     128;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =     128;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   60000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_70_DOUADY_RABBIT_01.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_70_DOUADY_RABBIT_01.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_70_DOUADY_RABBIT_01";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      36;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      36;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      17;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =   10000;

--- a/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_70_DOUADY_RABBIT_03.h
+++ b/mandelbrot/cfg/mandelbrot_cfg_MANDELBROT_70_DOUADY_RABBIT_03.h
@@ -10,7 +10,8 @@
 
   constexpr char MANDELBROT_FILENAME_STRING[]       = "MANDELBROT_70_DOUADY_RABBIT_03";
 
-  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      54;
+  constexpr int  MANDELBROT_SETUP_DIGITS10          =      54;
+  constexpr int  MANDELBROT_CALCULATION_DIGITS10    =      20;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_X    =    2048;
   constexpr int  MANDELBROT_CALCULATION_PIXELS_Y    =    2048;
   constexpr int  MANDELBROT_CALCULATION_ITERATIONS  =  100000;

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-﻿sonar.projectKey=ckormanyos_mandelbrot
-sonar.organization=ckormanyos
+﻿﻿sonar.projectKey=S-Streulicht_mandelbrot
+sonar.organization=s-streulicht
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=mandelbrot

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-﻿﻿sonar.projectKey=S-Streulicht_mandelbrot
-sonar.organization=s-streulicht
+﻿sonar.projectKey=ckormanyos_mandelbrot
+sonar.organization=ckormanyos
 
 # This is the name and version displayed in the SonarCloud UI.
 sonar.projectName=mandelbrot

--- a/test/test_mandelbrot.cpp
+++ b/test/test_mandelbrot.cpp
@@ -77,6 +77,7 @@ auto main() -> int // NOLINT(bugprone-exception-escape)
 
   using mandelbrot_generator_type =
     mandelbrot_generator<cfg::mandelbrot_numeric_type,
+                         cfg::mandelbrot_calc_numeric_type,
                          cfg::mandelbrot_config_type::max_iterations>;
 
         color::color_stretch_histogram_method local_color_stretches;


### PR DESCRIPTION
What do you get?
In MANDELBROT_20_ZOOM_VERY_DEEP_00 a factor of 10 in calculation speed (tested with a 64*64 image)
In MANDELBROT_05_SEAHORSES a los of factor 2 (tested on a 256*256 image)
reason: The contribution implements a calculation which requires only about 20 digits instead of zoom level + 20. Which means a huge perforance gain for calculations with previous high number of digits, such as 20_ZOOM from over 300 digits down to 20. but the SEAHORSES already had only 37 digits. Since the calculation is a bit more complexthe overall perfomane decreased.
THe formular used is exact. thus no rounding effects are present. Formular can be found in code or on https://de.wikipedia.org/wiki/Mandelbrot-Menge at "Deep Zoom und Störungsrechnung"
Downfalls:
a) The centralpoint of the images is a reference point. this one needst to be part of the mandelbrot set, or at least needs to be bound within the given iterations.
b) I implemented a message out if the centrap oint not fulfills a) -> Not covered by gcov -> less than 100% code coverage
c) some of the matrix test fails (gcc native) the calculated pictures have a different epected hash than the ones calculate with MS compiler. I don't know why. I would have expected that a portable code created same output on diffent compilers. This seams not to be the case. I don't kow if I made an error, or I just had to correct the expected hash in the github workflow.

Improvements:
a) The code is for sure not optimised. hence I expect  few percent more performance.
b) I an exact replication of the original pictures is not needed some few 10% optimiation can be doen to get a picture cose to the original:
b1) The number or alculation digits can be reduced a bit.
b2) to test if the caclolation is bound quad_length < 4 is tested in the loop. this can be changed to zer+zei and the calculation of quad_length is not needed. 
c) there might be room for imporovements in the optimisation of the calculation